### PR TITLE
Implement optional audio/video processing

### DIFF
--- a/media_processor.py
+++ b/media_processor.py
@@ -10,8 +10,15 @@ from __future__ import annotations
 
 import argparse
 import os
+import subprocess
+import shutil
 
 from summarizer import summarize_file
+
+try:  # optional dependency for speech to text
+    import speech_recognition as sr
+except Exception:  # pragma: no cover - optional
+    sr = None
 
 
 def process_text_file(path: str) -> str:
@@ -20,23 +27,47 @@ def process_text_file(path: str) -> str:
 
 
 def process_audio_file(path: str, response: str = "notation") -> str:
-    """Return a stub response for audio files.
-
-    Parameters
-    ----------
-    path:
-        Path to the audio file.
-    response:
-        Either "notation" or "tab" to indicate the desired output.
-    """
+    """Transcribe an audio file when speech recognition is available."""
     if response not in {"notation", "tab"}:
         raise ValueError("response must be 'notation' or 'tab'")
+
+    if sr is not None:
+        recognizer = sr.Recognizer()
+        with sr.AudioFile(path) as source:
+            audio_data = recognizer.record(source)
+        try:
+            text = recognizer.recognize_sphinx(audio_data)
+        except (sr.UnknownValueError, sr.RequestError):
+            text = ""
+        return text
+
     filename = os.path.basename(path)
     return f"[stub] Would generate {response} for {filename}"
 
 
 def process_video_file(path: str) -> str:
-    """Return a stub response for video files."""
+    """Return video duration when ffprobe is available."""
+    if shutil.which("ffprobe"):
+        try:
+            output = subprocess.check_output(
+                [
+                    "ffprobe",
+                    "-v",
+                    "error",
+                    "-show_entries",
+                    "format=duration",
+                    "-of",
+                    "default=noprint_wrappers=1:nokey=1",
+                    path,
+                ],
+                text=True,
+                stderr=subprocess.STDOUT,
+            )
+            duration = float(output.strip())
+            return f"Video duration: {duration:.2f} seconds"
+        except Exception:
+            pass
+
     filename = os.path.basename(path)
     return f"[stub] Would perform predictive analysis on {filename}"
 

--- a/tests/test_media_processor.py
+++ b/tests/test_media_processor.py
@@ -1,20 +1,47 @@
 import os
 import unittest
+from unittest.mock import patch, MagicMock
 
 from media_processor import process_audio_file, process_video_file, process_text_file
 
 class TestMediaProcessor(unittest.TestCase):
-    def test_process_audio_file_notation(self):
-        result = process_audio_file('song.wav', 'notation')
-        self.assertIn('notation', result)
+    def test_process_audio_file_notation_stub(self):
+        with patch('media_processor.sr', None):
+            result = process_audio_file('song.wav', 'notation')
+            self.assertIn('notation', result)
 
-    def test_process_audio_file_tab(self):
-        result = process_audio_file('song.mp3', 'tab')
-        self.assertIn('tab', result)
+    def test_process_audio_file_tab_stub(self):
+        with patch('media_processor.sr', None):
+            result = process_audio_file('song.mp3', 'tab')
+            self.assertIn('tab', result)
 
-    def test_process_video_file(self):
-        result = process_video_file('movie.mp4')
-        self.assertIn('predictive analysis', result)
+    def test_process_video_file_stub(self):
+        with patch('media_processor.shutil.which', return_value=None):
+            result = process_video_file('movie.mp4')
+            self.assertIn('predictive analysis', result)
+
+    def test_process_audio_file_with_sr(self):
+        fake_recognizer = MagicMock()
+        fake_recognizer.record.return_value = 'audio'
+        fake_recognizer.recognize_sphinx.return_value = 'hello world'
+        fake_audiofile = MagicMock()
+        fake_audiofile.__enter__.return_value = 'src'
+
+        fake_sr = MagicMock()
+        fake_sr.Recognizer.return_value = fake_recognizer
+        fake_sr.AudioFile.return_value = fake_audiofile
+        fake_sr.UnknownValueError = Exception
+        fake_sr.RequestError = Exception
+
+        with patch('media_processor.sr', fake_sr):
+            result = process_audio_file('song.wav')
+            self.assertIn('hello world', result)
+
+    def test_process_video_file_ffprobe(self):
+        with patch('media_processor.shutil.which', return_value='/usr/bin/ffprobe'):
+            with patch('media_processor.subprocess.check_output', return_value='12.0'):
+                result = process_video_file('movie.mp4')
+                self.assertIn('12.00', result)
 
     def test_process_text_file(self):
         path = 'temp.txt'


### PR DESCRIPTION
## Summary
- support optional speech-to-text via `speech_recognition`
- use ffprobe to detect video duration when available
- extend tests for audio/video paths with and without dependencies

## Testing
- `python3 -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_68459b6dfd608324899712378a691af4