### PR TITLE
Implement audio transcription to notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ files up to approximately **150 MB**. The summarization logic is implemented in
 algorithm.
 
 A lightweight helper `media_processor.py` is also included for working with
-text, audio and video files. Audio and video support are currently stubbed so
-no external dependencies are required.
+text, audio and video files. Audio input is now transcribed into musical
+notation or guitar tab using `librosa`. Install `librosa` and `soundfile` to
+enable this functionality. Video support remains a stub.
 
 ## Quick Start
 
@@ -23,15 +24,16 @@ the final summary.
 
 ### Handling audio and video
 
-Use `media_processor.py` to run the summarizer on text files or to invoke the
-stub handlers for audio and video formats:
+Use `media_processor.py` to run the summarizer on text files or to convert
+audio into notation or tab. Video files still return stub predictions:
 
 ```bash
-python3 media_processor.py path/to/file.wav --audio-response notation
+python3 media_processor.py path/to/file.wav --audio-response notation --clef treble
 ```
 
 The `--audio-response` option chooses between `notation` and `tab` modes when
-processing audio files.
+processing audio files. Use `--clef treble` or `--clef bass` when requesting
+notation to select the clef.
 
 ## Running Tests
 

--- a/media_processor.py
+++ b/media_processor.py
@@ -13,26 +13,98 @@ import os
 
 from summarizer import summarize_file
 
+try:
+    import librosa
+    import numpy as np
+except Exception:  # pragma: no cover - handled in tests
+    librosa = None  # type: ignore
+    np = None  # type: ignore
+
 
 def process_text_file(path: str) -> str:
     """Summarize a text file using the existing summarizer."""
     return summarize_file(path)
 
 
-def process_audio_file(path: str, response: str = "notation") -> str:
-    """Return a stub response for audio files.
+NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
 
-    Parameters
-    ----------
-    path:
-        Path to the audio file.
-    response:
-        Either "notation" or "tab" to indicate the desired output.
-    """
+
+def _hz_to_note_name(hz: float) -> str | None:
+    """Convert frequency in Hz to a note name like C4."""
+    if hz <= 0 or np is None:
+        return None
+    note_num = 12 * np.log2(hz / 440.0) + 69
+    index = int(round(note_num))
+    name = NOTE_NAMES[index % 12]
+    octave = index // 12 - 1
+    return f"{name}{octave}"
+
+
+def _extract_notes(path: str) -> list[str]:
+    """Extract a sequence of note names from an audio file."""
+    if librosa is None or np is None:
+        return []
+    y, sr = librosa.load(path)
+    pitches, magnitudes = librosa.piptrack(y=y, sr=sr)
+    notes: list[str] = []
+    for i in range(pitches.shape[1]):
+        index = magnitudes[:, i].argmax()
+        pitch = pitches[index, i]
+        name = _hz_to_note_name(float(pitch))
+        if name:
+            notes.append(name)
+    return notes
+
+
+OPEN_MIDI = {"E2": 40, "A2": 45, "D3": 50, "G3": 55, "B3": 59, "E4": 64}
+
+
+def _note_name_to_midi(note: str) -> int:
+    if np is None:
+        return 0
+    match = __import__("re").match(r"([A-G]#?)(-?\d+)", note)
+    if not match:
+        return 0
+    name, octave = match.groups()
+    semitone = NOTE_NAMES.index(name)
+    octave = int(octave)
+    return semitone + (octave + 1) * 12
+
+
+def _notes_to_tab(notes: list[str]) -> str:
+    """Convert note names to a simple guitar tab representation."""
+    lines = [[] for _ in range(6)]
+    open_notes = list(OPEN_MIDI.values())
+    for note in notes:
+        midi = _note_name_to_midi(note)
+        best_string = 0
+        best_fret = 1000
+        for idx, open_midi in enumerate(open_notes):
+            fret = midi - open_midi
+            if 0 <= fret < best_fret:
+                best_fret = fret
+                best_string = idx
+        for idx in range(6):
+            if idx == best_string:
+                lines[5 - idx].append(str(best_fret))
+            else:
+                lines[5 - idx].append("-")
+    return "\n".join("".join(l) for l in lines)
+
+
+def _notes_to_notation(notes: list[str], clef: str = "treble") -> str:
+    """Return a very naive text notation of notes."""
+    return f"Clef: {clef}\n" + " ".join(notes)
+
+
+def process_audio_file(path: str, response: str = "notation", clef: str = "treble") -> str:
+    """Transcribe audio to notes and format as notation or tab."""
     if response not in {"notation", "tab"}:
         raise ValueError("response must be 'notation' or 'tab'")
-    filename = os.path.basename(path)
-    return f"[stub] Would generate {response} for {filename}"
+    notes = _extract_notes(path)
+    if response == "tab":
+        return _notes_to_tab(notes)
+    return _notes_to_notation(notes, clef)
 
 
 def process_video_file(path: str) -> str:
@@ -58,13 +130,15 @@ def main() -> None:
     parser.add_argument("path", help="Path to the input file")
     parser.add_argument("--audio-response", choices=["notation", "tab"], default="notation",
                         help="Response format when processing audio files")
+    parser.add_argument("--clef", choices=["treble", "bass"], default="treble",
+                        help="Clef to use when returning notation")
     args = parser.parse_args()
 
     file_type = infer_type(args.path)
     if file_type == "text":
         result = process_text_file(args.path)
     elif file_type == "audio":
-        result = process_audio_file(args.path, args.audio_response)
+        result = process_audio_file(args.path, args.audio_response, args.clef)
     else:
         result = process_video_file(args.path)
 

--- a/tests/test_media_processor.py
+++ b/tests/test_media_processor.py
@@ -1,16 +1,30 @@
 import os
 import unittest
+import numpy as np
+import soundfile as sf
 
 from media_processor import process_audio_file, process_video_file, process_text_file
 
 class TestMediaProcessor(unittest.TestCase):
+    def setUp(self):
+        sr = 22050
+        t = np.linspace(0, 0.5, int(sr * 0.5), False)
+        tone = 0.5 * np.sin(2 * np.pi * 440 * t)
+        sf.write('song.wav', tone, sr)
+        sf.write('song.mp3', tone, sr)
+
+    def tearDown(self):
+        os.remove('song.wav')
+        os.remove('song.mp3')
+
     def test_process_audio_file_notation(self):
         result = process_audio_file('song.wav', 'notation')
-        self.assertIn('notation', result)
+        self.assertIn('Clef', result)
 
     def test_process_audio_file_tab(self):
         result = process_audio_file('song.mp3', 'tab')
-        self.assertIn('tab', result)
+        # Tab contains lines separated by newlines
+        self.assertIn('-', result)
 
     def test_process_video_file(self):
         result = process_video_file('movie.mp4')


### PR DESCRIPTION
## Summary
- transcribe audio into notes and convert to guitar tab or notation
- update CLI to allow `--clef` option for treble or bass
- adjust tests to generate audio samples for new audio processing
- document audio processing in the README

## Testing
- `python3 -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_684c7e96c4308324a959ca8d7462ebd9