### PR TITLE
Add OneDrive integration and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ python3 summarizer.py path/to/input.txt -o summary.txt
 Command‑line options allow customizing the chunk size and number of sentences in
 the final summary.
 
+### Uploading to OneDrive
+
+The summarizer can upload the resulting summary directly to OneDrive if you
+provide an OAuth access token:
+
+```bash
+python3 summarizer.py input.txt -o summary.txt \
+    --onedrive-path Documents/summary.txt --access-token YOUR_TOKEN
+```
+
+`onedrive_client.py` implements the minimal integration using the Microsoft
+Graph API. Ensure your token has permission to read and write files.
+
 ### Handling audio and video
 
 Use `media_processor.py` to run the summarizer on text files or to invoke the

--- a/onedrive_client.py
+++ b/onedrive_client.py
@@ -1,0 +1,34 @@
+import requests
+
+
+class OneDriveClient:
+    """Simple OneDrive client using Microsoft Graph API."""
+
+    GRAPH_API_ROOT = "https://graph.microsoft.com/v1.0/me/drive"  # root endpoint
+
+    def __init__(self, access_token: str) -> None:
+        self.access_token = access_token
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.access_token}"}
+
+    def upload_file(self, local_path: str, onedrive_path: str) -> requests.Response:
+        """Upload a local file to the specified OneDrive path."""
+        with open(local_path, "rb") as f:
+            url = f"{self.GRAPH_API_ROOT}/root:/{onedrive_path}:/content"
+            response = requests.put(url, headers=self._headers(), data=f)
+        response.raise_for_status()
+        return response
+
+    def download_file(self, onedrive_path: str, local_path: str) -> None:
+        """Download a file from OneDrive to the local filesystem."""
+        url = f"{self.GRAPH_API_ROOT}/root:/{onedrive_path}:/content"
+        response = requests.get(url, headers=self._headers(), stream=True)
+        response.raise_for_status()
+        with open(local_path, "wb") as out:
+            for chunk in response.iter_content(chunk_size=8192):
+                if chunk:
+                    out.write(chunk)
+
+
+__all__ = ["OneDriveClient"]

--- a/summarizer.py
+++ b/summarizer.py
@@ -1,6 +1,12 @@
 import re
 import heapq
 from typing import Iterable
+from typing import Optional
+
+try:
+    from onedrive_client import OneDriveClient
+except ImportError:  # pragma: no cover - optional dependency
+    OneDriveClient = None  # type: ignore
 
 # Basic set of stopwords for summarization
 STOPWORDS = {
@@ -56,13 +62,32 @@ def main() -> None:
                         help='Chunk size in bytes (default 5MB)')
     parser.add_argument('-n', '--sentences', type=int, default=5,
                         help='Number of sentences in summary')
+    parser.add_argument('--onedrive-path', help='Upload summary to this OneDrive path')
+    parser.add_argument('--access-token', help='OneDrive OAuth access token')
     args = parser.parse_args()
     summary = summarize_file(args.input, args.chunk_size, args.sentences)
-    if args.output:
-        with open(args.output, 'w', encoding='utf-8') as out:
+    output_path: Optional[str] = args.output
+    if output_path:
+        with open(output_path, 'w', encoding='utf-8') as out:
             out.write(summary)
     else:
-        print(summary)
+        if args.onedrive_path:
+            import tempfile
+            tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.txt')
+            output_path = tmp.name
+            with open(output_path, 'w', encoding='utf-8') as out:
+                out.write(summary)
+            print(summary)
+        else:
+            print(summary)
+
+    if args.onedrive_path:
+        if OneDriveClient is None:
+            raise RuntimeError('onedrive_client module is required for upload')
+        if not args.access_token:
+            raise RuntimeError('--access-token is required when using --onedrive-path')
+        client = OneDriveClient(args.access_token)
+        client.upload_file(output_path, args.onedrive_path)
 
 if __name__ == '__main__':
     main()

--- a/tests/test_onedrive_client.py
+++ b/tests/test_onedrive_client.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import patch, Mock
+
+from onedrive_client import OneDriveClient
+
+class TestOneDriveClient(unittest.TestCase):
+    def setUp(self):
+        self.client = OneDriveClient('token')
+
+    @patch('onedrive_client.requests.put')
+    def test_upload_file_calls_api(self, mock_put):
+        mock_response = Mock(status_code=201)
+        mock_response.raise_for_status = Mock()
+        mock_put.return_value = mock_response
+        with open('temp.txt', 'w') as f:
+            f.write('data')
+        self.client.upload_file('temp.txt', 'test.txt')
+        mock_put.assert_called()
+
+    @patch('onedrive_client.requests.get')
+    def test_download_file_calls_api(self, mock_get):
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.iter_content = Mock(return_value=[b'data'])
+        mock_get.return_value = mock_response
+        self.client.download_file('test.txt', 'out.txt')
+        mock_get.assert_called()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_summarizer_onedrive.py
+++ b/tests/test_summarizer_onedrive.py
@@ -1,0 +1,20 @@
+import unittest
+from unittest.mock import patch, Mock
+from summarizer import main
+
+class TestSummarizerOneDrive(unittest.TestCase):
+    @patch('summarizer.OneDriveClient')
+    def test_cli_upload(self, mock_client):
+        # Prepare mocks
+        instance = mock_client.return_value
+        instance.upload_file.return_value = None
+        with open('file.txt', 'w') as f:
+            f.write('content')
+        argv = ['summarizer.py', 'file.txt', '-o', 'out.txt', '--onedrive-path', 'Docs/out.txt', '--access-token', 'tok']
+        with patch('sys.argv', argv):
+            main()
+        mock_client.assert_called_with('tok')
+        instance.upload_file.assert_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a small OneDrive client for upload/download
- extend summarizer CLI with optional OneDrive upload feature
- document how to upload summaries to OneDrive
- test OneDrive client and CLI upload functionality

## Testing
- `python3 -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_6854af4c9d608324a63f4d69a69c3e5b